### PR TITLE
Add ability for checking out a version of filetranspiler repo

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -371,6 +371,7 @@
   - name: Downloading filetranspiler source
     git:
       repo: https://github.com/ashcrow/filetranspiler
+      version: "{{ filetranspiler_version | default('master') }}"
       dest: /usr/local/src/filetranspiler
     when: install_filetranspiler
 


### PR DESCRIPTION
If nothing is specified, then it will take master by default.  Possibly push this upstream. Don't delete this branch. 

Signed-off-by: Victor Hu <whowutwut@gmail.com>