### PR TITLE
All ability to selectively add certain worker nodes to the OpenShift Cluster

### DIFF
--- a/docs/examples/vars-nightlies.yaml
+++ b/docs/examples/vars-nightlies.yaml
@@ -35,12 +35,15 @@ workers:
   - name: "worker0"
     ipaddr: "192.168.7.11"
     macaddr: "52:54:00:f4:26:a1"
+    add_to_ocp: True
   - name: "worker1"
     ipaddr: "192.168.7.12"
     macaddr: "52:54:00:82:90:00"
+    add_to_ocp: True
   - name: "worker2"
     ipaddr: "192.168.7.13"
     macaddr: "52:54:00:8e:10:34"
+    add_to_ocp: True
 ocp_bios: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest/rhcos-42.80.20190828.2-metal-bios.raw.gz"
 ocp_initramfs: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest/rhcos-42.80.20190828.2-installer-initramfs.img"
 ocp_install_kernel: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest/rhcos-42.80.20190828.2-installer-kernel"

--- a/docs/examples/vars-static-nightlies.yaml
+++ b/docs/examples/vars-static-nightlies.yaml
@@ -22,10 +22,13 @@ masters:
 workers:
   - name: "worker0"
     ipaddr: "192.168.7.11"
+    add_to_ocp: True
   - name: "worker1"
     ipaddr: "192.168.7.12"
+    add_to_ocp: True
   - name: "worker2"
     ipaddr: "192.168.7.13"
+    add_to_ocp: True
 ocp_bios: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest/rhcos-42.80.20190828.2-metal-bios.raw.gz"
 ocp_initramfs: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest/rhcos-42.80.20190828.2-installer-initramfs.img"
 ocp_install_kernel: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest/rhcos-42.80.20190828.2-installer-kernel"

--- a/docs/examples/vars-static.yaml
+++ b/docs/examples/vars-static.yaml
@@ -22,7 +22,10 @@ masters:
 workers:
   - name: "worker0"
     ipaddr: "192.168.7.11"
+    add_to_ocp: True
   - name: "worker1"
     ipaddr: "192.168.7.12"
+    add_to_ocp: True
   - name: "worker2"
     ipaddr: "192.168.7.13"
+    add_to_ocp: True

--- a/docs/examples/vars.yaml
+++ b/docs/examples/vars.yaml
@@ -35,9 +35,12 @@ workers:
   - name: "worker0"
     ipaddr: "192.168.7.11"
     macaddr: "52:54:00:f4:26:a1"
+    add_to_ocp: True
   - name: "worker1"
     ipaddr: "192.168.7.12"
     macaddr: "52:54:00:82:90:00"
+    add_to_ocp: True
   - name: "worker2"
     ipaddr: "192.168.7.13"
     macaddr: "52:54:00:8e:10:34"
+    add_to_ocp: True

--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -15,10 +15,10 @@ max-lease-time 14400;
         	range {{ dhcp.poolstart }} {{ dhcp.poolend }};
 		# Static entries
 		host {{ bootstrap.name }} { hardware ethernet {{ bootstrap.macaddr }}; fixed-address {{ bootstrap.ipaddr }}; }
-{% for m in masters %}
+{% for m in masters if m.macaddr %}
 		host {{ m.name }} { hardware ethernet {{ m.macaddr }}; fixed-address {{ m.ipaddr }}; }
 {% endfor %}
-{% for w in workers %}
+{% for w in workers if w.macaddr %}
 		host {{ w.name }} { hardware ethernet {{ w.macaddr }}; fixed-address {{ w.ipaddr }}; }
 {% endfor %}
 		# this will not give out addresses to hosts not listed above

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -104,7 +104,7 @@ frontend ingress-http
 backend ingress-http
     balance source
     mode tcp
-{% for w in workers %}
+{% for w in workers if w.add_to_ocp %}
     server {{ w.name }}-http-router{{ loop.index0 }} {{ w.ipaddr }}:80 check
 {% endfor %}
    
@@ -117,7 +117,7 @@ frontend ingress-https
 backend ingress-https
     balance source
     mode tcp
-{% for w in workers %}
+{% for w in workers if w.add_to_ocp %}
     server {{ w.name }}-https-router{{ loop.index0 }} {{ w.ipaddr }}:443 check
 {% endfor %}
 


### PR DESCRIPTION
The DHCP commit test for mac is to allow for the helper node to control the OS or not.  We have another DHCP server that can install a different OS, such as RHEL, so when we don't want the helper node to install the OS and control that, we just remove the mac address from the config. 

The other commit is to toggle  whether nodes should be added into the OpenShift cluster. If not, we don't want those workers to be part of the HAPROXY pool.  This is an internal use case, so no plans to push this Upstream. 